### PR TITLE
Fix duplicate homepage title

### DIFF
--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -23,7 +23,11 @@ const {
   title: inTitle,
 } = meta
 
-const title = inTitle === GLOBAL_CONFIG.name ? inTitle : `${inTitle} - ${GLOBAL_CONFIG.name}`
+const siteNameLower = GLOBAL_CONFIG.name.trim().toLowerCase()
+const providedTitleLower = (inTitle ?? '').trim().toLowerCase()
+const title = providedTitleLower.includes(siteNameLower)
+  ? inTitle
+  : `${inTitle} - ${GLOBAL_CONFIG.name}`
 
 // Clean and optimize the description for meta tags
 const description = stripHtmlAndTruncate(inDescription, 160, '...')


### PR DESCRIPTION
Prevent site name duplication in page titles by checking if the provided title already includes the site name before appending it.

---
Linear Issue: [VOLTA-181](https://linear.app/lukemcdonald/issue/VOLTA-181/fix-homepage-page-title)

<a href="https://cursor.com/background-agent?bcId=bc-0b9f51f4-aedf-4b88-8256-aa4514c0630c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b9f51f4-aedf-4b88-8256-aa4514c0630c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

