### PR TITLE
Improve resume date display format

### DIFF
--- a/src/components/PostHog.astro
+++ b/src/components/PostHog.astro
@@ -41,7 +41,7 @@
             },
             o =
               'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId'.split(
-                ' '
+                ' ',
               ),
             n = 0;
           n < o.length;

--- a/src/features/resume/components/Experience.astro
+++ b/src/features/resume/components/Experience.astro
@@ -5,6 +5,7 @@ import ExperienceIcon from '@lucide/astro/icons/shield-ellipsis'
 
 import Link from '@/components/Link.astro'
 import Section from '@/features/resume/components/ui/Section.astro'
+import { formatMonthYear } from '@/utils/dates'
 
 export interface Props {
   experience: ExperienceItem[]
@@ -40,13 +41,15 @@ const { experience } = Astro.props
             <dt class="sr-only">Date</dt>
             <dd
               class="my-0 ml-1 text-sm text-primary-600 md:ml-auto dark:text-primary-400"
-              aria-label={`${item.startDate} until ${item.endDate || 'Present'}`}
+              aria-label={`${formatMonthYear(item.startDate) || item.startDate} until ${formatMonthYear(item.endDate) || 'Present'}`}
             >
-              <time datetime={item.startDate}>{item.startDate}</time>
-              <span aria-hidden="true">
-                <em>to</em>
-              </span>
-              <time datetime={item.endDate || 'Present'}>{item.endDate || 'Present'}</time>
+              <time datetime={item.startDate}>
+                {formatMonthYear(item.startDate) || item.startDate}
+              </time>
+              <span aria-hidden="true">&nbsp;–&nbsp;</span>
+              <time datetime={item.endDate || 'Present'}>
+                {formatMonthYear(item.endDate) || 'Present'}
+              </time>
             </dd>
           </dl>
 

--- a/src/features/resume/components/ui/Section.astro
+++ b/src/features/resume/components/ui/Section.astro
@@ -30,7 +30,7 @@ const hasItemSlot = Astro.slots.has('item')
 let renderedItemSlots: string[] = []
 if (hasItems && hasItemSlot) {
   renderedItemSlots = await Promise.all(
-    items.map((item, index) => Astro.slots.render('item', [item, index]))
+    items.map((item, index) => Astro.slots.render('item', [item, index])),
   )
 }
 ---

--- a/src/utils/dates/formatMonthYear.ts
+++ b/src/utils/dates/formatMonthYear.ts
@@ -1,0 +1,20 @@
+import { isValid } from 'date-fns'
+
+import { toDate } from './toDate'
+
+/**
+ * Format a date-like value as Mon YYYY (e.g., Jan 2023).
+ * Returns null if the input cannot be parsed as a valid date.
+ */
+export function formatMonthYear(input: unknown): string | null {
+  const d = toDate(input as never)
+  if (!d || !isValid(d)) {
+    return null
+  }
+
+  // Use a fixed en-US short month for resume readability.
+  // Avoid toLocaleDateString variability by specifying locale-independent options.
+  const month = d.toLocaleString('en-US', { month: 'short' }).replace('.', '') // Normalize locales that add periods (e.g., "Sept.")
+  const year = d.getFullYear()
+  return `${month} ${year}`
+}

--- a/src/utils/dates/index.ts
+++ b/src/utils/dates/index.ts
@@ -1,5 +1,6 @@
 export type DateLike = Date | string | number | null | undefined
 
+export { formatMonthYear } from './formatMonthYear'
 export { getDateKey } from './getDateKey'
 export { sortByAccessorDateDesc } from './sortByAccessorDateDesc'
 export { sortByDateDesc } from './sortByDateDesc'

--- a/src/utils/dates/sortByAccessorDateDesc.ts
+++ b/src/utils/dates/sortByAccessorDateDesc.ts
@@ -1,5 +1,7 @@
-import { compareDesc } from 'date-fns'
 import type { DateLike } from './index'
+
+import { compareDesc } from 'date-fns'
+
 import { toDate } from './toDate'
 
 /**


### PR DESCRIPTION
Improve date display in the resume experience section to a more readable "Mon YYYY – Mon YYYY/Present" format.

---
Linear Issue: [VOLTA-178](https://linear.app/lukemcdonald/issue/VOLTA-178/improve-date-display-in-resume-experience-section)

<a href="https://cursor.com/background-agent?bcId=bc-8643b145-f5f6-4c96-8237-117b3fb7f490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8643b145-f5f6-4c96-8237-117b3fb7f490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

