### PR TITLE
feat: update entry header description to a slot

### DIFF
--- a/src/components/Entry/Entry.astro
+++ b/src/components/Entry/Entry.astro
@@ -22,7 +22,12 @@ const { description, image, imageAlt, subtitle, title } = Astro.props
     description={description}
     subtitle={subtitle}
     title={title}
-  />
+  >
+    <slot
+      slot="description"
+      name="description"
+    />
+  </EntryHeader>
 
   <ContactInfo />
 

--- a/src/components/Entry/EntryHeader.astro
+++ b/src/components/Entry/EntryHeader.astro
@@ -12,6 +12,7 @@ export interface Props {
 }
 
 const { description, subtitle, title } = Astro.props
+const hasDescriptionSlot = Astro.slots.has('description')
 ---
 
 <header
@@ -36,7 +37,14 @@ const { description, subtitle, title } = Astro.props
     >
       {title}.
     </Heading>
-    {description && <EntryHeaderDescription description={description} />}
+    {
+      hasDescriptionSlot ?
+        <EntryHeaderDescription>
+          <slot name="description" />
+        </EntryHeaderDescription>
+      : description ? <EntryHeaderDescription description={description} />
+      : null
+    }
   </div>
 
   <Mountains class="absolute bottom-0 left-0 z-0 w-full" />

--- a/src/components/Entry/EntryHeaderDescription.astro
+++ b/src/components/Entry/EntryHeaderDescription.astro
@@ -2,10 +2,11 @@
 import GreetingLinks from '@/components/GreetingLinks.astro'
 
 export interface Props {
-  description: string
+  description?: string
 }
 
 const { description } = Astro.props
+const hasDefaultSlot = Astro.slots.has('default')
 
 const descriptionComponents = {
   GreetingLinks,
@@ -15,5 +16,10 @@ const isComponent = Boolean(Component)
 ---
 
 <div class="text-lg leading-normal text-pretty">
-  {isComponent ? <Component /> : <slot set:html={description} />}
+  {
+    hasDefaultSlot ? <slot />
+    : isComponent ? <Component />
+    : description ? <slot set:html={description} />
+    : null
+  }
 </div>

--- a/src/components/PostHog.astro
+++ b/src/components/PostHog.astro
@@ -33,7 +33,7 @@
             },
             o =
               'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId'.split(
-                ' '
+                ' ',
               ),
             n = 0;
           n < o.length;


### PR DESCRIPTION
Refactor `EntryHeaderDescription` to accept a default slot, enabling rich content while maintaining backward compatibility.

---
Linear Issue: [VOLTA-172](https://linear.app/lukemcdonald/issue/VOLTA-172/make-entryheaderdescription-a-slot)

<a href="https://cursor.com/background-agent?bcId=bc-19065d34-960d-4311-8152-4b70dd5d560d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19065d34-960d-4311-8152-4b70dd5d560d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

