### PR TITLE
Implement public google site verification

### DIFF
--- a/src/configs/env.ts
+++ b/src/configs/env.ts
@@ -1,14 +1,14 @@
 import { envField } from 'astro/config'
 
 export const ENV_SCHEMA = {
+  GOOGLE_SITE_VERIFICATION: envField.string({
+    access: 'public',
+    context: 'client',
+    optional: true,
+  }),
   POSTHOG_API_KEY: envField.string({
     access: 'public',
     context: 'client',
     default: 'phc_uOQ6lcaumKxM0PL2tuStM1uioEePx2JfFB7680cpHQF',
-  }),
-  PUBLIC_GOOGLE_SITE_VERIFICATION: envField.string({
-    access: 'public',
-    context: 'client',
-    optional: true,
   }),
 }

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -2,6 +2,7 @@
 import type { SeoMeta } from '@/utils/seo'
 
 import { ClientRouter } from 'astro:transitions'
+import { PUBLIC_GOOGLE_SITE_VERIFICATION } from 'astro:env/client'
 
 import PostHog from '@/components/PostHog.astro'
 import { GLOBAL_CONFIG, IS_PROD } from '@/configs/global'
@@ -45,6 +46,13 @@ const socialMetaTags = buildSocialMetaTags(metaForSeo)
     name="robots"
     content="index, follow, max-image-preview:large"
   />
+
+  {PUBLIC_GOOGLE_SITE_VERIFICATION && (
+    <meta
+      name="google-site-verification"
+      content={PUBLIC_GOOGLE_SITE_VERIFICATION}
+    />
+  )}
 
   <!-- Favicon -->
   <link

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -1,8 +1,8 @@
 ---
 import type { SeoMeta } from '@/utils/seo'
 
+import { GOOGLE_SITE_VERIFICATION } from 'astro:env/client'
 import { ClientRouter } from 'astro:transitions'
-import { PUBLIC_GOOGLE_SITE_VERIFICATION } from 'astro:env/client'
 
 import PostHog from '@/components/PostHog.astro'
 import { GLOBAL_CONFIG, IS_PROD } from '@/configs/global'
@@ -47,12 +47,14 @@ const socialMetaTags = buildSocialMetaTags(metaForSeo)
     content="index, follow, max-image-preview:large"
   />
 
-  {PUBLIC_GOOGLE_SITE_VERIFICATION && (
-    <meta
-      name="google-site-verification"
-      content={PUBLIC_GOOGLE_SITE_VERIFICATION}
-    />
-  )}
+  {
+    GOOGLE_SITE_VERIFICATION && (
+      <meta
+        name="google-site-verification"
+        content={GOOGLE_SITE_VERIFICATION}
+      />
+    )
+  }
 
   <!-- Favicon -->
   <link


### PR DESCRIPTION
Add conditional Google site verification meta tag to support `PUBLIC_GOOGLE_SITE_VERIFICATION` env var.

This PR addresses Linear issue VOLTA-188 by implementing the `PUBLIC_GOOGLE_SITE_VERIFICATION` environment variable, which was previously defined in the Astro env schema but not utilized in the codebase. This allows for proper Google site verification.

---
Linear Issue: [VOLTA-188](https://linear.app/lukemcdonald/issue/VOLTA-188/add-support-for-public-google-site-verification)

<a href="https://cursor.com/background-agent?bcId=bc-b28d8273-5f6d-4832-a0b7-52753b0e1781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b28d8273-5f6d-4832-a0b7-52753b0e1781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically adds a Google site verification meta tag when configured, enabling seamless search engine verification.

* **Chores**
  * Renamed environment variables and adjusted their required/optional behavior.
  * Analytics key now has a default value; site verification is optional to set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->